### PR TITLE
Fix name of Oct 2020 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ I can only advise you to put an exclusion on the Win10XPE folder.<br/><br/>
 - Windows 10 1903 (May 2019 Update)<br/>
 - Windows 10 1909 (Nov 2019 Update)<br/>
 - Windows 10 2004 (May 2020 Update)<br/>
-- Windows 10 2009 (Oct 2020 Update)<br/>
+- Windows 10 20H2 (Oct 2020 Update)<br/>
 
 Have Fun :)


### PR DESCRIPTION
Microsoft named the Oct 2020 update 20H2, not 2009. Updated the Readme to reflect this.